### PR TITLE
Graceful shutdown: SIGTERM, in-flight request draining, /ready health semantics, clean pool close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 * Shutdown now waits for in-flight requests to complete; the wait was previously hardcoded to 1 second, so every restart killed any request slower than that. The new `GracefulShutdownTimeout` config key (seconds, default 0 = wait until done) bounds the wait for deployments that want a hard cap below their supervisor's stop grace period. A second signal during the wait forces an immediate exit, and `Shutdown()` is now idempotent.
+* `/ready` now reports `503 {"status":"draining"}` as soon as a graceful shutdown begins, while `/live` keeps answering 200 until the process exits — the standard probe contract for zero-downtime rolling deploys. The new `DrainDelay` config key (seconds, default 0 = disabled) keeps the listener serving for that long after readiness flips, giving load balancers time to deregister the instance before it stops accepting connections. The delay applies to SIGTERM only; an interactive Ctrl-C (SIGINT) shuts down immediately, and a second signal during the window skips it.
 
 ### Fixed
 * Schema cache held in an atomic pointer (was a data race on reload).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * **`::cast` injection** — cast targets in `select` are validated at parse time and rejected with 400 otherwise; a cast can't be a bind parameter, so it was interpolated verbatim and could alter the SELECT (reachable by any role that can read).
 * **DDL quoting** — quote the remaining `CREATE`/`ALTER DATABASE` identifiers, and whitelist grant/revoke verbs and object types instead of interpolating them.
 
+### Added
+* Shutdown now waits for in-flight requests to complete; the wait was previously hardcoded to 1 second, so every restart killed any request slower than that. The new `GracefulShutdownTimeout` config key (seconds, default 0 = wait until done) bounds the wait for deployments that want a hard cap below their supervisor's stop grace period. A second signal during the wait forces an immediate exit, and `Shutdown()` is now idempotent.
+
 ### Fixed
 * Schema cache held in an atomic pointer (was a data race on reload).
 * Serializers return an error on a malformed wire buffer or a type/dimension mismatch instead of panicking or silently misparsing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Session watcher no longer deadlocks when paused.
 * **SIGTERM** — the server now shuts down gracefully on SIGTERM (the default stop signal of Docker, Kubernetes and systemd), not only on SIGINT/Ctrl-C. A raw SIGTERM previously terminated the process immediately, cutting in-flight requests and resetting database connections.
 * **Exit status** — a graceful shutdown now exits with status 0; it previously exited 1, which supervisors interpret as a crash.
+* **Database connections on shutdown** — connection pools and the notification listener's dedicated connection are now closed after the HTTP server drains, so Postgres sees clean disconnects instead of connection resets on every stop. `NotificationListener.Stop()` now interrupts a pending `WaitForNotification` and waits for the listener goroutine to exit before returning.
 
 ## 0.8.1 - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Invalid grant input returns 400 instead of 500.
 * Session watcher no longer deadlocks when paused.
 * **SIGTERM** — the server now shuts down gracefully on SIGTERM (the default stop signal of Docker, Kubernetes and systemd), not only on SIGINT/Ctrl-C. A raw SIGTERM previously terminated the process immediately, cutting in-flight requests and resetting database connections.
+* **Exit status** — a graceful shutdown now exits with status 0; it previously exited 1, which supervisors interpret as a crash.
 
 ## 0.8.1 - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Boolean-filter nesting capped at 100 levels (stack-overflow DoS).
 * Invalid grant input returns 400 instead of 500.
 * Session watcher no longer deadlocks when paused.
+* **SIGTERM** — the server now shuts down gracefully on SIGTERM (the default stop signal of Docker, Kubernetes and systemd), not only on SIGINT/Ctrl-C. A raw SIGTERM previously terminated the process immediately, cutting in-flight requests and resetting database connections.
 
 ## 0.8.1 - 2026-07-08
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ update-ui:
 
 test:
 	$(GO) test $(TEST_FLAGS) ./database
+	$(GO) test $(TEST_FLAGS) ./server
 	$(GO) test $(TEST_FLAGS) ./test/api
 	$(GO) test $(TEST_FLAGS) ./test/postgrest
 	$(GO) test $(TEST_FLAGS) ./test/recursive

--- a/README.md
+++ b/README.md
@@ -772,6 +772,7 @@ The configuration file *config.jsonc* (JSON with Comments) is created automatica
 | Plugins | Ordered list of plugins | [] |
 | ReadTimeout | The maximum duration for reading the entire request, including the body (seconds) | 60 |
 | WriteTimeout | The maximum duration before timing out writes of the response (seconds) | 60 |
+| GracefulShutdownTimeout | The maximum duration to wait for in-flight requests to complete on shutdown (seconds, 0 to wait until done) | 0 |
 | RequestMaxBytes | Max bytes allowed in requests, to limit the size of incoming request bodies (0 for unlimited) | 1048576 (1MB) |
 | Database.URL | Database URL as postgresql://user:pwd@host:port/database | "" |
 | Database.MinPoolConnections | Miminum connections per pool | 10 |

--- a/README.md
+++ b/README.md
@@ -773,6 +773,7 @@ The configuration file *config.jsonc* (JSON with Comments) is created automatica
 | ReadTimeout | The maximum duration for reading the entire request, including the body (seconds) | 60 |
 | WriteTimeout | The maximum duration before timing out writes of the response (seconds) | 60 |
 | GracefulShutdownTimeout | The maximum duration to wait for in-flight requests to complete on shutdown (seconds, 0 to wait until done) | 0 |
+| DrainDelay | Seconds to keep serving after /ready starts reporting 503 on a SIGTERM shutdown, so load balancers can deregister the instance; SIGINT skips the delay (0 to disable) | 0 |
 | RequestMaxBytes | Max bytes allowed in requests, to limit the size of incoming request bodies (0 for unlimited) | 1048576 (1MB) |
 | Database.URL | Database URL as postgresql://user:pwd@host:port/database | "" |
 | Database.MinPoolConnections | Miminum connections per pool | 10 |

--- a/api/health.go
+++ b/api/health.go
@@ -11,13 +11,25 @@ import (
 func InitHealthRoutes(apiHelper Helper) {
 	router := apiHelper.GetRouter()
 
-	// Register both health check endpoints with the same handler
-	router.Handle("GET", "/live", HealthHandler)
-	router.Handle("GET", "/ready", HealthHandler)
+	router.Handle("GET", "/live", LiveHandler)
+	router.Handle("GET", "/ready", ReadyHandler(apiHelper))
 }
 
-// HealthHandler handles both /live and /ready endpoints
-func HealthHandler(c context.Context, w http.ResponseWriter, r heligo.Request) (int, error) {
-	// If this handler is executing, the server is up and ready
+// LiveHandler handles the /live endpoint: the process is up. It deliberately
+// keeps answering 200 while the server drains — a graceful shutdown must not
+// look like a hung process.
+func LiveHandler(c context.Context, w http.ResponseWriter, r heligo.Request) (int, error) {
 	return heligo.WriteJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// ReadyHandler returns the handler for the /ready endpoint: route traffic to
+// this instance. It flips to 503 as soon as a shutdown begins, so load
+// balancers deregister the instance while it is still serving.
+func ReadyHandler(apiHelper Helper) heligo.Handler {
+	return func(c context.Context, w http.ResponseWriter, r heligo.Request) (int, error) {
+		if apiHelper.IsDraining() {
+			return heligo.WriteJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "draining"})
+		}
+		return heligo.WriteJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
 }

--- a/api/helper.go
+++ b/api/helper.go
@@ -21,6 +21,7 @@ type Helper interface {
 	BaseAdminURL() string
 	BaseAPIURL() string
 	HasShortAPIURL() bool
+	IsDraining() bool
 
 	SessionStatistics() authn.SessionStatistics
 }

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -17,6 +17,10 @@ func TestMain(m *testing.M) {
 	var err error
 	config := DefaultConfig()
 	config.URL = "postgresql://postgres:postgres@0.0.0.0:5432/postgres"
+	// Same override the server honors, already exported by CI
+	if url := os.Getenv("SMOOTHDB_DATABASE_URL"); url != "" {
+		config.URL = url
+	}
 	dbe, err = InitDbEngine(config, nil)
 	if err != nil {
 		fmt.Println(err.Error())

--- a/database/notification_listener.go
+++ b/database/notification_listener.go
@@ -35,11 +35,11 @@ type NotificationListener struct {
 	config     *ListenerConfig
 	logger     *logging.Logger
 	connString string
-	conn       *pgx.Conn
 	handlers   map[string]NotificationHandler
 	mu         sync.RWMutex
 	running    bool
-	stop       chan struct{}
+	cancel     context.CancelFunc
+	stopped    chan struct{}
 }
 
 // NewNotificationListener creates a new notification listener
@@ -52,7 +52,6 @@ func NewNotificationListener(connString string, config *ListenerConfig, logger *
 		logger:     logger,
 		connString: connString,
 		handlers:   make(map[string]NotificationHandler),
-		stop:       make(chan struct{}),
 	}
 }
 
@@ -78,44 +77,52 @@ func (l *NotificationListener) Start(ctx context.Context) error {
 		return fmt.Errorf("listener is already running")
 	}
 	l.running = true
+	ctx, l.cancel = context.WithCancel(ctx)
+	l.stopped = make(chan struct{})
+	stopped := l.stopped
 	l.mu.Unlock()
 
-	go l.listenLoop(ctx)
+	go func() {
+		defer close(stopped)
+		l.listenLoop(ctx)
+	}()
 	return nil
 }
 
-// Stop stops the listener
+// Stop stops the listener, interrupting a pending WaitForNotification, and
+// waits for the loop to exit, so its dedicated connection is closed when
+// Stop returns — also when racing another Stop. It must not be called from
+// a notification handler, which runs on the loop it would wait for.
 func (l *NotificationListener) Stop() {
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	if l.running {
-		close(l.stop)
 		l.running = false
+		l.cancel()
+	}
+	stopped := l.stopped
+	l.mu.Unlock()
+	if stopped != nil {
+		<-stopped
 	}
 }
 
 // listenLoop maintains the connection and processes notifications
 func (l *NotificationListener) listenLoop(ctx context.Context) {
 	for {
-		select {
-		case <-ctx.Done():
+		err := l.connectAndListen(ctx)
+		if ctx.Err() != nil {
+			// Stopped: WaitForNotification reports the canceled
+			// context as an error, not worth logging
 			return
-		case <-l.stop:
-			return
-		default:
-			err := l.connectAndListen(ctx)
-			if err != nil {
-				if l.logger != nil {
-					l.logger.Err(err).Msg("Notification listener error")
-				}
-				select {
-				case <-time.After(l.config.ReconnectDelay):
-					continue
-				case <-ctx.Done():
-					return
-				case <-l.stop:
-					return
-				}
+		}
+		if err != nil {
+			if l.logger != nil {
+				l.logger.Err(err).Msg("Notification listener error")
+			}
+			select {
+			case <-time.After(l.config.ReconnectDelay):
+			case <-ctx.Done():
+				return
 			}
 		}
 	}
@@ -127,9 +134,13 @@ func (l *NotificationListener) connectAndListen(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to connect: %w", err)
 	}
-	defer conn.Close(ctx)
-
-	l.conn = conn
+	defer func() {
+		// Close cleanly even when ctx is already canceled (i.e. during
+		// Stop), so Postgres sees a Terminate message instead of a reset
+		closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		defer cancel()
+		conn.Close(closeCtx)
+	}()
 
 	_, err = conn.Exec(ctx, fmt.Sprintf("LISTEN %s", l.config.Channel))
 	if err != nil {
@@ -141,20 +152,12 @@ func (l *NotificationListener) connectAndListen(ctx context.Context) error {
 	}
 
 	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-l.stop:
-			return nil
-		default:
-			notification, err := conn.WaitForNotification(ctx)
-			if err != nil {
-				return fmt.Errorf("error waiting for notification: %w", err)
-			}
-
-			if notification != nil {
-				l.handleNotification(ctx, notification.Payload)
-			}
+		notification, err := conn.WaitForNotification(ctx)
+		if err != nil {
+			return fmt.Errorf("error waiting for notification: %w", err)
+		}
+		if notification != nil {
+			l.handleNotification(ctx, notification.Payload)
 		}
 	}
 }

--- a/database/notification_listener_test.go
+++ b/database/notification_listener_test.go
@@ -1,0 +1,37 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Stop must interrupt the listener even while it is blocked in
+// WaitForNotification, and return only once the loop has exited and its
+// dedicated connection is closed. It used to leave both behind: the stop
+// channel was only checked between notifications.
+func TestListenerStopInterruptsWait(t *testing.T) {
+	l := NewNotificationListener(dbe.config.URL, nil, nil)
+	if err := l.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// Let the listener connect and block waiting for notifications
+	time.Sleep(200 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		l.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop did not return: listener stuck in WaitForNotification")
+	}
+
+	// The listener must be restartable after a stop
+	if err := l.Start(context.Background()); err != nil {
+		t.Fatalf("restart after Stop failed: %v", err)
+	}
+	l.Stop()
+}

--- a/server/config.go
+++ b/server/config.go
@@ -24,64 +24,66 @@ type ConfigOptions struct {
 
 // Config holds the current configuration
 type Config struct {
-	Address              string          `comment:"Server address and port (default: 0.0.0.0:4000)"`
-	CertFile             string          `comment:"TLS certificate file (default: '')"`
-	KeyFile              string          `comment:"TLS certificate key file (default: '')"`
-	LoginMode            string          `comment:"Login mode: none, db, gotrue (default: none)"`
-	AuthURL              string          `comment:"URL of the external AuthN service (default: '')"`
-	AllowAnon            bool            `comment:"Allow unauthenticated connections (default: false)"`
-	JWTSecret            string          `comment:"Secret for JWT tokens"`
-	SessionMode          string          `comment:"Session mode: none, role (default: role)"`
-	EnableAdminRoute     bool            `comment:"Enable administration of databases and tables (default: false)"`
-	EnableAdminUI        bool            `comment:"Enable Admin dashboard (default: false)"`
-	EnableAPIRoute       bool            `comment:"Enable API access (default: true)"`
-	BaseAPIURL           string          `comment:"Base URL for the API (default: /api)"`
-	ShortAPIURL          bool            `comment:"Avoid database name in API URL (needs a single allowed database)"`
-	BaseAdminURL         string          `comment:"Base URL for the Admin API (default: /admin)"`
-	CORSAllowedOrigins   []string        `comment:"CORS Access-Control-Allow-Origin (default: [*] for all)"`
-	CORSAllowCredentials bool            `comment:"CORS Access-Control-Allow-Credentials (default: false)"`
-	EnableDebugRoute     bool            `comment:"Enable debug access (default: false)"`
-	PluginDir            string          `comment:"Plugins' directory (default: ./_plugins)"`
-	Plugins              []string        `comment:"Ordered list of plugins (default: [])"`
-	ReadTimeout          int64           `comment:"The maximum duration (seconds) for reading the entire request, including the body (default: 60)"`
-	WriteTimeout         int64           `comment:"The maximum duration before timing out writes of the response (default: 60)"`
-	TokenExpiry          int64           `comment:"JWT token expiry in seconds (default: 86400 = 24h, 0 for no expiry)"`
-	VerboseErrors        bool            `comment:"Return full database error details (hint, detail) to clients (default: true)"`
-	RequestMaxBytes      int64           `comment:"Max bytes allowed in requests, to limit the size of incoming request bodies (default: 1M, 0 for unlimited)"`
-	Database             database.Config `comment:"Database configuration"`
-	JQ                   jqeval.Config   `comment:"jq evaluation configuration"`
-	Logging              logging.Config  `comment:"Logging configuration"`
+	Address                 string          `comment:"Server address and port (default: 0.0.0.0:4000)"`
+	CertFile                string          `comment:"TLS certificate file (default: '')"`
+	KeyFile                 string          `comment:"TLS certificate key file (default: '')"`
+	LoginMode               string          `comment:"Login mode: none, db, gotrue (default: none)"`
+	AuthURL                 string          `comment:"URL of the external AuthN service (default: '')"`
+	AllowAnon               bool            `comment:"Allow unauthenticated connections (default: false)"`
+	JWTSecret               string          `comment:"Secret for JWT tokens"`
+	SessionMode             string          `comment:"Session mode: none, role (default: role)"`
+	EnableAdminRoute        bool            `comment:"Enable administration of databases and tables (default: false)"`
+	EnableAdminUI           bool            `comment:"Enable Admin dashboard (default: false)"`
+	EnableAPIRoute          bool            `comment:"Enable API access (default: true)"`
+	BaseAPIURL              string          `comment:"Base URL for the API (default: /api)"`
+	ShortAPIURL             bool            `comment:"Avoid database name in API URL (needs a single allowed database)"`
+	BaseAdminURL            string          `comment:"Base URL for the Admin API (default: /admin)"`
+	CORSAllowedOrigins      []string        `comment:"CORS Access-Control-Allow-Origin (default: [*] for all)"`
+	CORSAllowCredentials    bool            `comment:"CORS Access-Control-Allow-Credentials (default: false)"`
+	EnableDebugRoute        bool            `comment:"Enable debug access (default: false)"`
+	PluginDir               string          `comment:"Plugins' directory (default: ./_plugins)"`
+	Plugins                 []string        `comment:"Ordered list of plugins (default: [])"`
+	ReadTimeout             int64           `comment:"The maximum duration (seconds) for reading the entire request, including the body (default: 60)"`
+	WriteTimeout            int64           `comment:"The maximum duration before timing out writes of the response (default: 60)"`
+	GracefulShutdownTimeout int64           `comment:"The maximum duration (seconds) to wait for in-flight requests to complete on shutdown (default: 0, wait until done)"`
+	TokenExpiry             int64           `comment:"JWT token expiry in seconds (default: 86400 = 24h, 0 for no expiry)"`
+	VerboseErrors           bool            `comment:"Return full database error details (hint, detail) to clients (default: true)"`
+	RequestMaxBytes         int64           `comment:"Max bytes allowed in requests, to limit the size of incoming request bodies (default: 1M, 0 for unlimited)"`
+	Database                database.Config `comment:"Database configuration"`
+	JQ                      jqeval.Config   `comment:"jq evaluation configuration"`
+	Logging                 logging.Config  `comment:"Logging configuration"`
 }
 
 func defaultConfig() *Config {
 	return &Config{
-		Address:              "0.0.0.0:4000",
-		CertFile:             "",
-		KeyFile:              "",
-		LoginMode:            "none",
-		AuthURL:              "",
-		AllowAnon:            false,
-		JWTSecret:            "",
-		SessionMode:          "role",
-		EnableAdminRoute:     false,
-		EnableAdminUI:        false,
-		EnableAPIRoute:       true,
-		BaseAPIURL:           "/api",
-		ShortAPIURL:          false,
-		BaseAdminURL:         "/admin",
-		CORSAllowedOrigins:   []string{},
-		CORSAllowCredentials: false,
-		EnableDebugRoute:     false,
-		PluginDir:            "./_plugins",
-		Plugins:              []string{},
-		ReadTimeout:          60,
-		WriteTimeout:         60,
-		TokenExpiry:          86400,
-		VerboseErrors:        true,
-		RequestMaxBytes:      1024 * 1024,
-		Database:             *database.DefaultConfig(),
-		JQ:                   *jqeval.DefaultConfig(),
-		Logging:              *logging.DefaultConfig(),
+		Address:                 "0.0.0.0:4000",
+		CertFile:                "",
+		KeyFile:                 "",
+		LoginMode:               "none",
+		AuthURL:                 "",
+		AllowAnon:               false,
+		JWTSecret:               "",
+		SessionMode:             "role",
+		EnableAdminRoute:        false,
+		EnableAdminUI:           false,
+		EnableAPIRoute:          true,
+		BaseAPIURL:              "/api",
+		ShortAPIURL:             false,
+		BaseAdminURL:            "/admin",
+		CORSAllowedOrigins:      []string{},
+		CORSAllowCredentials:    false,
+		EnableDebugRoute:        false,
+		PluginDir:               "./_plugins",
+		Plugins:                 []string{},
+		ReadTimeout:             60,
+		WriteTimeout:            60,
+		GracefulShutdownTimeout: 0,
+		TokenExpiry:             86400,
+		VerboseErrors:           true,
+		RequestMaxBytes:         1024 * 1024,
+		Database:                *database.DefaultConfig(),
+		JQ:                      *jqeval.DefaultConfig(),
+		Logging:                 *logging.DefaultConfig(),
 	}
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -122,7 +122,7 @@ func getEnvironment(c *Config) {
 	if enableAdminRoute != "" {
 		c.EnableAdminRoute = strings.ToLower(enableAdminRoute) == "true"
 	}
-	
+
 	// CORS configuration
 	corsAllowedOrigins := os.Getenv("SMOOTHDB_CORS_ALLOWED_ORIGINS")
 	if corsAllowedOrigins != "" {

--- a/server/config.go
+++ b/server/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	ReadTimeout             int64           `comment:"The maximum duration (seconds) for reading the entire request, including the body (default: 60)"`
 	WriteTimeout            int64           `comment:"The maximum duration before timing out writes of the response (default: 60)"`
 	GracefulShutdownTimeout int64           `comment:"The maximum duration (seconds) to wait for in-flight requests to complete on shutdown (default: 0, wait until done)"`
+	DrainDelay              int64           `comment:"Seconds to keep serving after /ready starts reporting 503 on a SIGTERM shutdown, so load balancers can deregister the instance; SIGINT skips the delay (default: 0, disabled)"`
 	TokenExpiry             int64           `comment:"JWT token expiry in seconds (default: 86400 = 24h, 0 for no expiry)"`
 	VerboseErrors           bool            `comment:"Return full database error details (hint, detail) to clients (default: true)"`
 	RequestMaxBytes         int64           `comment:"Max bytes allowed in requests, to limit the size of incoming request bodies (default: 1M, 0 for unlimited)"`
@@ -78,6 +79,7 @@ func defaultConfig() *Config {
 		ReadTimeout:             60,
 		WriteTimeout:            60,
 		GracefulShutdownTimeout: 0,
+		DrainDelay:              0,
 		TokenExpiry:             86400,
 		VerboseErrors:           true,
 		RequestMaxBytes:         1024 * 1024,

--- a/server/http_server_test.go
+++ b/server/http_server_test.go
@@ -1,6 +1,9 @@
 package server
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 // A configured-but-unloadable TLS certificate must be a hard error, not a silent
 // fall-through to plaintext HTTP (which would expose Bearer tokens and login
@@ -14,6 +17,9 @@ func TestLoadTLSConfigFailsClosed(t *testing.T) {
 
 // The dev certificate in the repo root should load into a usable TLS config.
 func TestLoadTLSConfigValidCert(t *testing.T) {
+	if _, err := os.Stat("../localhost.pem"); os.IsNotExist(err) {
+		t.Skip("dev certificate not present (generate with mkcert localhost)")
+	}
 	cfg, err := loadTLSConfig("../localhost.pem", "../localhost-key.pem")
 	if err != nil {
 		t.Fatalf("expected valid cert to load, got: %v", err)

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -31,6 +32,7 @@ type Server struct {
 	shutdown          chan struct{}
 	shutdownCompleted chan struct{}
 	shutdownOnce      sync.Once
+	draining          atomic.Bool
 	OnBeforeStart     func(*Server)
 	OnBeforeShutdown  func(*Server)
 }
@@ -105,6 +107,7 @@ func (s *Server) Start() error {
 // and an embedder may both call it.
 func (s *Server) Shutdown(ctx context.Context) {
 	s.shutdownOnce.Do(func() {
+		s.draining.Store(true)
 		if s.OnBeforeShutdown != nil {
 			s.OnBeforeShutdown(s)
 		}
@@ -126,8 +129,20 @@ func (s *Server) Shutdown(ctx context.Context) {
 // still takes the default disposition (immediate termination).
 func (s *Server) stopHandler(c chan os.Signal) {
 	defer signal.Stop(c)
-	<-c
+	sig := <-c
 	fmt.Println("\nStarting shutdown...")
+	// Flip readiness first: /ready reports 503 while the listener is still
+	// accepting, giving load balancers a window (DrainDelay) to deregister
+	// the instance before it stops serving. The window only makes sense for
+	// orchestrated stops (SIGTERM): an interactive Ctrl-C skips it, and a
+	// second signal cuts it short.
+	s.draining.Store(true)
+	if delay := time.Duration(s.Config.DrainDelay) * time.Second; delay > 0 && sig == syscall.SIGTERM {
+		select {
+		case <-time.After(delay):
+		case <-c:
+		}
+	}
 	// No deadline by default: in-flight requests are already bounded by
 	// ReadTimeout/WriteTimeout, and the supervisor's stop grace period is
 	// the final backstop.
@@ -147,8 +162,13 @@ func (s *Server) stopHandler(c chan os.Signal) {
 	select {
 	case <-done:
 	case <-c:
-		fmt.Println("\nShutdown forced")
-		os.Exit(1)
+		// A signal racing shutdown completion is not a force request
+		select {
+		case <-done:
+		default:
+			fmt.Println("\nShutdown forced")
+			os.Exit(1)
+		}
 	}
 }
 
@@ -206,6 +226,11 @@ func (s *Server) BaseAPIURL() string {
 
 func (s *Server) HasShortAPIURL() bool {
 	return s.Config.ShortAPIURL
+}
+
+// IsDraining reports whether a graceful shutdown has begun
+func (s *Server) IsDraining() bool {
+	return s.draining.Load()
 }
 
 func (s *Server) RequestMaxBytes() int64 {

--- a/server/server.go
+++ b/server/server.go
@@ -130,7 +130,10 @@ func (s *Server) Run() {
 	err := s.Start()
 	if err != nil {
 		if err == http.ErrServerClosed {
+			// Graceful shutdown is a clean exit: supervisors (systemd, k8s)
+			// treat a non-zero status as a crash.
 			fmt.Println("Stopped.")
+			return
 		} else if errors.Is(err, syscall.EADDRINUSE) {
 			fmt.Printf("EndPoint address already in use. Is there another smoothdb running? (%s)\n", err)
 		} else {

--- a/server/server.go
+++ b/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -29,6 +30,7 @@ type Server struct {
 	sessionManager    *authn.SessionManager
 	shutdown          chan struct{}
 	shutdownCompleted chan struct{}
+	shutdownOnce      sync.Once
 	OnBeforeStart     func(*Server)
 	OnBeforeShutdown  func(*Server)
 }
@@ -98,17 +100,24 @@ func (s *Server) Start() error {
 	return err
 }
 
+// Shutdown stops the server gracefully, waiting for in-flight requests
+// within ctx's deadline. It is idempotent: the signal path installed by Run
+// and an embedder may both call it.
 func (s *Server) Shutdown(ctx context.Context) {
-	if s.OnBeforeShutdown != nil {
-		s.OnBeforeShutdown(s)
-	}
-	// HTTP server shutdown
-	s.HTTP.Shutdown(ctx)
-	// Close goroutines (for now just the checker in the service manager)
-	close(s.shutdown)
-	// Close database pools - ok, not so graceful
-	// s.DBE.Close() @@ to be fixed, now blocks
-	close(s.shutdownCompleted)
+	s.shutdownOnce.Do(func() {
+		if s.OnBeforeShutdown != nil {
+			s.OnBeforeShutdown(s)
+		}
+		// HTTP server shutdown
+		if err := s.HTTP.Shutdown(ctx); err != nil {
+			s.logger.Warn().Err(err).Msg("Graceful window expired, forcing remaining connections closed")
+		}
+		// Close goroutines (for now just the checker in the service manager)
+		close(s.shutdown)
+		// Close database pools - ok, not so graceful
+		// s.DBE.Close() @@ to be fixed, now blocks
+		close(s.shutdownCompleted)
+	})
 }
 
 // stopHandler waits for a shutdown signal on c and stops the server. The
@@ -116,11 +125,31 @@ func (s *Server) Shutdown(ctx context.Context) {
 // in a goroutine racing the listener, would leave a window where a signal
 // still takes the default disposition (immediate termination).
 func (s *Server) stopHandler(c chan os.Signal) {
+	defer signal.Stop(c)
 	<-c
-	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-	defer cancel()
 	fmt.Println("\nStarting shutdown...")
-	s.Shutdown(ctx)
+	// No deadline by default: in-flight requests are already bounded by
+	// ReadTimeout/WriteTimeout, and the supervisor's stop grace period is
+	// the final backstop.
+	ctx := context.Background()
+	if timeout := time.Duration(s.Config.GracefulShutdownTimeout) * time.Second; timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	// A second signal during the graceful wait forces an immediate exit,
+	// so a stuck drain can always be cut short without resorting to SIGKILL.
+	done := make(chan struct{})
+	go func() {
+		s.Shutdown(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-c:
+		fmt.Println("\nShutdown forced")
+		os.Exit(1)
+	}
 }
 
 func (s *Server) Run() {

--- a/server/server.go
+++ b/server/server.go
@@ -117,8 +117,24 @@ func (s *Server) Shutdown(ctx context.Context) {
 		}
 		// Close goroutines (for now just the checker in the service manager)
 		close(s.shutdown)
-		// Close database pools - ok, not so graceful
-		// s.DBE.Close() @@ to be fixed, now blocks
+		// Release database resources: the notification listener and all the
+		// connection pools. Handlers have completed by now, so pool Close()
+		// does not wait on acquired connections — unless the graceful window
+		// expired with requests still running, so bound the wait (by ctx,
+		// plus a backstop when ctx has no deadline) rather than hang past
+		// the supervisor's grace period.
+		closed := make(chan struct{})
+		go func() {
+			s.DBE.Close()
+			close(closed)
+		}()
+		select {
+		case <-closed:
+		case <-ctx.Done():
+			s.logger.Warn().Msg("Shutdown context expired while closing database pools")
+		case <-time.After(5 * time.Second):
+			s.logger.Warn().Msg("Timed out closing database pools")
+		}
 		close(s.shutdownCompleted)
 	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -111,9 +111,11 @@ func (s *Server) Shutdown(ctx context.Context) {
 	close(s.shutdownCompleted)
 }
 
-func (s *Server) stopHandler() {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+// stopHandler waits for a shutdown signal on c and stops the server. The
+// channel must already be registered with signal.Notify: registering it here,
+// in a goroutine racing the listener, would leave a window where a signal
+// still takes the default disposition (immediate termination).
+func (s *Server) stopHandler(c chan os.Signal) {
 	<-c
 	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
 	defer cancel()
@@ -122,7 +124,9 @@ func (s *Server) stopHandler() {
 }
 
 func (s *Server) Run() {
-	go s.stopHandler()
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go s.stopHandler(c)
 	err := s.Start()
 	if err != nil {
 		if err == http.ErrServerClosed {

--- a/server/shutdown_test.go
+++ b/server/shutdown_test.go
@@ -81,6 +81,92 @@ func TestSIGTERMStartsGracefulShutdown(t *testing.T) {
 	waitStopped(t, done, 10*time.Second)
 }
 
+func getStatus(t *testing.T, url string) int {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
+// During the drain window (DrainDelay) /ready must report 503 so load
+// balancers deregister the instance, while /live stays 200 and the listener
+// keeps serving; only afterwards does the server stop accepting connections.
+func TestReadyReportsDrainingDuringShutdown(t *testing.T) {
+	s := newTestServer(t, map[string]any{
+		"Address":    "localhost:8093",
+		"DrainDelay": int64(2),
+	})
+	done := startTestServer(t, s)
+	base := "http://localhost:8093"
+
+	if got := getStatus(t, base+"/ready"); got != http.StatusOK {
+		t.Fatalf("expected 200 from /ready before shutdown, got %d", got)
+	}
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	// Readiness flips before the drain sleep starts, so the 503 must show up
+	// almost immediately — poll briefly, then check /live in the same breath,
+	// well inside the 2s drain window.
+	deadline := time.Now().Add(1 * time.Second)
+	for getStatus(t, base+"/ready") != http.StatusServiceUnavailable {
+		if time.Now().After(deadline) {
+			t.Fatal("/ready did not report draining within the drain window")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := getStatus(t, base+"/live"); got != http.StatusOK {
+		t.Fatalf("expected 200 from /live while draining, got %d", got)
+	}
+	waitStopped(t, done, 10*time.Second)
+}
+
+// The drain window is for orchestrated stops: an interactive Ctrl-C (SIGINT)
+// must skip DrainDelay and shut down immediately.
+func TestSIGINTSkipsDrainDelay(t *testing.T) {
+	s := newTestServer(t, map[string]any{
+		"Address":    "localhost:8094",
+		"DrainDelay": int64(30),
+	})
+	done := startTestServer(t, s)
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatal(err)
+	}
+	waitStopped(t, done, 5*time.Second)
+}
+
+// A second signal during the drain window must cut it short and proceed with
+// the graceful shutdown right away.
+func TestSecondSignalSkipsDrainWindow(t *testing.T) {
+	s := newTestServer(t, map[string]any{
+		"Address":    "localhost:8095",
+		"DrainDelay": int64(30),
+	})
+	done := startTestServer(t, s)
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	// Wait until the handler has consumed the first signal (readiness flips
+	// right after) — a second signal sent while the first still sits in the
+	// channel's one-slot buffer would be dropped, not queued.
+	deadline := time.Now().Add(1 * time.Second)
+	for getStatus(t, "http://localhost:8095/ready") != http.StatusServiceUnavailable {
+		if time.Now().After(deadline) {
+			t.Fatal("/ready did not report draining")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	waitStopped(t, done, 5*time.Second)
+}
+
 // Shutdown must wait for in-flight requests up to GracefulShutdownTimeout.
 // With the previous hardcoded 1s window this request (2s) was cut off with a
 // connection reset instead of completing.

--- a/server/shutdown_test.go
+++ b/server/shutdown_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"os/signal"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sted/heligo"
 	"github.com/sted/smoothdb/test"
 )
 
@@ -75,6 +77,50 @@ func TestSIGTERMStartsGracefulShutdown(t *testing.T) {
 
 	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
 		t.Fatal(err)
+	}
+	waitStopped(t, done, 10*time.Second)
+}
+
+// Shutdown must wait for in-flight requests up to GracefulShutdownTimeout.
+// With the previous hardcoded 1s window this request (2s) was cut off with a
+// connection reset instead of completing.
+func TestShutdownWaitsForInflightRequests(t *testing.T) {
+	s := newTestServer(t, map[string]any{
+		"Address":                 "localhost:8092",
+		"GracefulShutdownTimeout": int64(10),
+	})
+	s.GetRouter().Handle("GET", "/slow", func(ctx context.Context, w http.ResponseWriter, r heligo.Request) (int, error) {
+		time.Sleep(2 * time.Second)
+		return heligo.WriteJSON(w, http.StatusOK, map[string]string{"status": "done"})
+	})
+	done := startTestServer(t, s)
+
+	type result struct {
+		status int
+		err    error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		resp, err := http.Get("http://localhost:8092/slow")
+		if err != nil {
+			resCh <- result{0, err}
+			return
+		}
+		resp.Body.Close()
+		resCh <- result{resp.StatusCode, nil}
+	}()
+	// Let the slow request reach its handler before stopping the server.
+	time.Sleep(300 * time.Millisecond)
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+
+	res := <-resCh
+	if res.err != nil {
+		t.Fatalf("in-flight request failed during shutdown: %v", res.err)
+	}
+	if res.status != http.StatusOK {
+		t.Fatalf("expected status 200 for in-flight request, got %d", res.status)
 	}
 	waitStopped(t, done, 10*time.Second)
 }

--- a/server/shutdown_test.go
+++ b/server/shutdown_test.go
@@ -79,6 +79,11 @@ func TestSIGTERMStartsGracefulShutdown(t *testing.T) {
 		t.Fatal(err)
 	}
 	waitStopped(t, done, 10*time.Second)
+
+	// Shutdown must also have closed the database pools
+	if _, err := s.DBE.AcquireConnection(context.Background()); err == nil {
+		t.Fatal("expected the main pool to be closed after shutdown")
+	}
 }
 
 func getStatus(t *testing.T, url string) int {

--- a/server/shutdown_test.go
+++ b/server/shutdown_test.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sted/smoothdb/test"
+)
+
+// newTestServer builds a server for shutdown tests. The database URL defaults
+// to the one used in CI; NewServerWithConfig itself honors SMOOTHDB_DATABASE_URL,
+// so a local override just works.
+func newTestServer(t *testing.T, config map[string]any) *Server {
+	t.Helper()
+	base := map[string]any{
+		"Database.URL":        "postgresql://postgres:postgres@localhost:5432/postgres",
+		"Logging.FileLogging": false,
+		"Logging.StdOut":      false,
+	}
+	for k, v := range config {
+		base[k] = v
+	}
+	s, err := NewServerWithConfig(base, &ConfigOptions{
+		ConfigFilePath: filepath.Join(t.TempDir(), "config.jsonc"),
+		SkipFlags:      true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// startTestServer runs the server and its signal handler — with the signal
+// channel registered before the listener starts, as in Run() — and waits for
+// the HTTP listener to accept connections. The returned channel receives the
+// result of Start() when the server stops.
+func startTestServer(t *testing.T, s *Server) chan error {
+	t.Helper()
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	done := make(chan error, 1)
+	go func() { done <- s.Start() }()
+	go s.stopHandler(c)
+
+	test.WaitForServer("http://" + s.Config.Address)
+	return done
+}
+
+// waitStopped asserts that the server stops with http.ErrServerClosed (the
+// graceful path) within the given timeout.
+func waitStopped(t *testing.T, done chan error, timeout time.Duration) {
+	t.Helper()
+	select {
+	case err := <-done:
+		if err != http.ErrServerClosed {
+			t.Fatalf("expected http.ErrServerClosed, got %v", err)
+		}
+	case <-time.After(timeout):
+		t.Fatal("server did not shut down in time")
+	}
+}
+
+// A raw SIGTERM — the default stop signal of Docker, Kubernetes and systemd —
+// must start the same graceful shutdown as SIGINT/Ctrl-C. Without the handler
+// the runtime default applies and the process is terminated immediately
+// (which here would kill the whole test binary).
+func TestSIGTERMStartsGracefulShutdown(t *testing.T) {
+	s := newTestServer(t, map[string]any{"Address": "localhost:8091"})
+	done := startTestServer(t, s)
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	waitStopped(t, done, 10*time.Second)
+}


### PR DESCRIPTION
### Motivation

smoothdb currently doesn't survive a standard rolling deploy (or a plain restart) without dropping work:

- A raw **SIGTERM** — the default stop signal of Docker, Kubernetes and systemd — terminated the process immediately (only SIGINT was handled), cutting in-flight requests mid-response and resetting Postgres connections.
- Even on SIGINT, the shutdown context was hardcoded to **1 second**, while `ReadTimeout`/`WriteTimeout` allow requests to run for 60 — so every restart killed any request slower than ~1s.
- `/live` and `/ready` were the same unconditional 200 handler, so a load balancer had no way to deregister an instance before its listener closed.
- Database pools were never closed on shutdown (`s.DBE.Close()` was commented out as "now blocks"), so Postgres saw connection resets on every stop.
- A clean stop exited with status 1, which supervisors read as a crash.

PostgREST recently addressed the same gaps — shutdown waiting for in-flight requests ([PostgREST/postgrest#4689](https://github.com/PostgREST/postgrest/issues/4689), fixed in [#4702](https://github.com/PostgREST/postgrest/pull/4702)) and a pre-shutdown wait for load-balancer deregistration ([#4580](https://github.com/PostgREST/postgrest/pull/4580), `server-shutdown-wait-period`). This PR follows the same model, and where they differ, kube-apiserver's `--shutdown-delay-duration` / traefik's `requestAcceptGraceTimeout` shape.

### What changes

One commit per fix/feature, in dependency order:

1. **`fix: shut down gracefully on SIGTERM, not only SIGINT`** — registers SIGTERM alongside SIGINT, synchronously in `Run()` before the listener starts (so an early signal can't hit the default disposition).
2. **`fix: exit 0 after a graceful shutdown`** — `http.ErrServerClosed` is a clean stop, not an error.
3. **`feat: wait for in-flight requests on shutdown, with optional bound`** — shutdown now waits for in-flight requests **indefinitely by default** (they're already bounded per-request by `ReadTimeout`/`WriteTimeout`; the supervisor's stop grace period is the final backstop — same model as PostgREST). A new **`GracefulShutdownTimeout`** config key (seconds, `0` = wait until done) bounds the wait. Because the wait is no longer trivially short: a **second signal forces an immediate exit**, `Shutdown()` is **idempotent** (`sync.Once`), and an expired graceful window is logged.
4. **`feat: report draining on /ready during shutdown, with optional drain window`** — `/ready` flips to `503 {"status":"draining"}` as soon as shutdown begins while `/live` keeps answering 200 (the standard probe contract). A new **`DrainDelay`** config key (seconds, `0` = disabled) keeps the listener serving that long after readiness flips, so load balancers can observe the 503 and deregister before connections start being refused — the k8s preStop-sleep pattern internalized. The delay applies to **SIGTERM only** (orchestrated stops); an interactive Ctrl-C skips it, and a second signal cuts it short. Same semantics as PostgREST's `server-shutdown-wait-period`.
5. **`test: honor SMOOTHDB_DATABASE_URL in database package tests`** — CI already exports it; this was the only suite ignoring it.
6. **`fix: close database pools and notification listener on shutdown`** — un-comments the pool close and fixes both reasons it used to block: the 1s window abandoned handlers still holding connections, and `NotificationListener.Stop()` didn't interrupt a pending `WaitForNotification` (the goroutine and its dedicated connection survived `Stop`). The listener now cancels its loop context, closes the connection with a bounded fresh context (Postgres receives a proper `Terminate` instead of a reset), and `Stop` waits for the goroutine to exit. `Server.Shutdown` closes the engine after the HTTP drain, bounded by the shutdown context plus a 5s backstop.
7. **`test: run the server package in make test`** — the new tests live in `./server`, which `make test` (and CI) didn't run.

### New config keys

| Key | Meaning | Default |
|---|---|---|
| `GracefulShutdownTimeout` | Max seconds to wait for in-flight requests on shutdown (`0` = wait until done) | `0` |
| `DrainDelay` | Seconds to keep serving after `/ready` starts reporting 503 on a SIGTERM shutdown (`0` = disabled) | `0` |

Both default to inert values: with an empty config, behavior only changes in that shutdown is now actually graceful.

### Shutdown sequence (with both keys set)

```
SIGTERM → /ready starts answering 503 (listener still serving)
        → wait DrainDelay (LB observes the 503 and deregisters; second signal skips the wait)
        → stop accepting, wait for in-flight requests (≤ GracefulShutdownTimeout; second signal forces exit)
        → close notification listener + connection pools (clean disconnects in Postgres)
        → exit 0
```

### Compatibility notes

- `api.Helper` gained an `IsDraining() bool` method — a compile-time break for external implementers of that interface (in-repo, `*server.Server` is the only one).
- The exported `api.HealthHandler` was replaced by `LiveHandler` and `ReadyHandler(Helper)`.
- `stopHandler` now takes the signal channel (unexported, no API impact).

### Testing

- 6 new integration tests in `server/shutdown_test.go` (run with `-race`): SIGTERM graceful path + pools closed, in-flight request completing across shutdown, `/ready` 503 + `/live` 200 during the drain window, SIGINT skipping the drain, a second signal skipping the drain, and a listener `Stop`-interrupts-`WaitForNotification` test in `database/`.
- Full suite passes: `SMOOTHDB_DATABASE_URL=... make test` (CI-equivalent env; verified on Postgres 16).
- Verified end-to-end on the binary: `kill -TERM` → drain → "Stopped." → exit 0; second SIGTERM during a 30s drain window → immediate graceful stop.

### Out of scope / follow-ups

- `/ready` verifying the main connection pool (PostgREST checks pool + schema cache state) — natural next step.
- Two pre-existing issues found while testing, will file separately: the ACL parser doesn't know PG17's `MAINTAIN` privilege (`m`), so `TestGrants` fails on Postgres 17; and `InitDbEngine` writes the package-global `dbe`, which races when two engines exist in one process.
